### PR TITLE
Fixed airgapped install issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,3 +530,9 @@ You should keep your installer/cluster_id directory because the ssh keys that yo
 If you delete your cluster and want to reinstall, you will need to remove the installer/cluster_id directory or the install will likely fail when you start the VM's. You will see messages referencing x.509 certificate errors in the logs of the bootstrap and other servers if you forget to delete the directory.
 
 `rm -rf installer/<your cluster id>`
+
+You don't need to recreate your Bastion everytime you want to create a cluster but if you want to recreate you your Bastion, you should first delete any clusters by issuing
+ `terraform destroy` followed by
+ `terraform -chdir=bastion-vm apply --var-file="../terraform.tfvars" --auto-approve` on your Host machine.
+
+ If you delete the Bastion via some other method, remember to delete the FW, DNAT and SNAT rule associated with the Bastion. They will be tagged with references to the Bastion

--- a/README.md
+++ b/README.md
@@ -505,6 +505,10 @@ In order for the accept CSR code to work, you will have to
 
 You should edit your pull secret and remove the section that refers to `cloud.openshift.com`. This removes Telemetry and Health Reporting. If you don't do this before installation, you will get an error in the insights operator. After installation, go [here](https://docs.openshift.com/container-platform/4.6/support/remote_health_monitoring/opting-out-of-remote-health-reporting.html) for instructions to disable Telemetry Reporting.
 
+Run this command to stop OpenShift from looking for Operators from the Online source.  
+
+`oc patch OperatorHub cluster --type json  -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'`
+
 You may receive an Alert stating `Cluster version operator has not retrieved updates in xh xxm 17s. Failure reason RemoteFailed . For more information refer to https://console-openshift-console.apps.<cluster_id>.<base_domain>.com/settings/cluster/` this is normal and can be ignored.
 
 You will also need to mirror any operators that you will need and place them in the mirror. Instructions can be found [here](https://docs.openshift.com/container-platform/4.6/operators/admin/olm-restricted-networks.html)

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ $ ls -l /etc/hosts
 | openshift_host_prefix        | Controls the number of pods to allocate to each node from the `openshift_cluster_cidr` CIDR. For example, 23 would allocate 2^(32-23) 512 pods to each node. | string | 23               |
 | cluster_public_ip |Public IP address to be used for your OCP Cluster Console   |  string |   |
 |create_vms_only   |  **Experimental** If you set this to true, running `terraform apply` will fail after bootstrap machine. Just run `terraform apply` again and it should complete sucessfully | bool  | false |
+|bastion_disk   |disk size of bastion disk   | string  |  ~200GB |
 |openshift_version   |  The version of OpenShift you want to install | string  | 4.6  |
 |additional_trust_bundle   |  name of file containing cert for mirror. Read OCP restricted network install doc. Cert name should match DNS name.  | string  |  - |
 |**initialization_info object** |   |   |   |

--- a/main.tf
+++ b/main.tf
@@ -470,12 +470,13 @@ data "template_file" "write_final_args" {
 This information stored in: /root/${var.cluster_id}info.txt on the Bastion and the Home Directory of the Host Machine.   
 **********************************************************************************************************************
 
-Kubeadmin         : User: kubeadmin password: ${data.local_file.kubeadmin_password.content}
-Bastion Public IP : ${var.initialization_info["public_bastion_ip"]}   ssh -i ~/.ssh/id_bastion root@${var.initialization_info["public_bastion_ip"]}  
-Bastion Privat IP : ${var.initialization_info["internal_bastion_ip"]}
-Public IP         : ${var.cluster_public_ip}
-OpenShift Console : ${local.openshift_console_url}
-Export KUBECONFIG : ${local.export_kubeconfig}
+Kubeadmin                      : User: kubeadmin password: ${data.local_file.kubeadmin_password.content}
+Bastion Public IP              : ${var.initialization_info["public_bastion_ip"]}   ssh -i ~/.ssh/id_bastion root@${var.initialization_info["public_bastion_ip"]}  
+Bastion Privat IP              : ${var.initialization_info["internal_bastion_ip"]}
+Login to Bootstrap from Bastion: ssh -i ${path.cwd}/installer/${var.cluster_id}/openshift_rsa core@${var.bootstrap_ip_address}
+Public IP                      : ${var.cluster_public_ip}
+OpenShift Console              : ${local.openshift_console_url}
+Export KUBECONFIG              : ${local.export_kubeconfig}
 
 Host File Entries:
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,30 +1,31 @@
+
+
+
+
 // ID identifying the cluster to create. Use your username so that resources created can be tracked back to you.
 
-cluster_id = "cluster id"
+cluster_id = "<your cluster id"
 
 // Base domain from which the cluster domain is a subdomain.
-base_domain = "xxxx.com"
+base_domain = "<your base domain>"
 
 // Name of the VDC.
-vcd_vdc = "your vdc name"
+vcd_vdc = "<your vdc name>"
 
 // User on the vSphere server.
 vcd_user = "admin"
 
-// Password of the user on the vcd console.
-vcd_password = "xxxyyyxxxsss"
+// Password of the user on vcd.
+vcd_password = "<your password>"
 
 // Name of the VCD organization. Found on the VCD console, Data Centers tab
-vcd_org = "long currently 33 character string retrieved from vdc console"
+vcd_org = "<your org id>"
 
-// url for the vcd. (this is frankfurt)
-vcd_url = "https://fradir01.vmware-solutions.cloud.ibm.com/api"
+// url for the vcd. (this is dal)
+vcd_url = "https://daldir01.vmware-solutions.cloud.ibm.com/api"
 
-// make sure you change the template when you change the version
-openshift_version="4.6"
 
-// Name of the RHCOS VM template to clone to create VMs for the cluster
-rhcos_template = "rhcos OpenShift 4.6.8"
+
 
 // Name of the vcd Catalog
 vcd_catalog = "Public Catalog"
@@ -35,7 +36,7 @@ vcd_catalog = "Public Catalog"
 
 // The IP address to assign to the bootstrap VM.
 bootstrap_disk = 250000
-bootstrap_ip_address = "172.16.0.20"
+bootstrap_ip_address = "172.16.0.70"
 
 
 // The number of control plane VMs to create. Default is 3.
@@ -43,62 +44,65 @@ control_plane_count = 3
 control_disk = 250000
 // The IP addresses to assign to the control plane VMs. The length of this list
 // must match the value of control_plane_count.
-  control_plane_ip_addresses = ["172.16.0.21", "172.16.0.22", "172.16.0.23"]
+  control_plane_ip_addresses = ["172.16.0.71", "172.16.0.72", "172.16.0.73"]
+//    control_plane_ip_addresses = ["172.16.0.51"]
 
 
 
 
 // The number of compute VMs to create. Default is 3.
-compute_count = 3
+compute_count = 2
 compute_disk =250000
 
 // The IP addresses to assign to the compute VMs. The length of this list must
 // match the value of compute_count.
-     compute_ip_addresses = ["172.16.0.24","172.16.0.25","172.16.0.26"]
+   compute_ip_addresses = ["172.16.0.74","172.16.0.75"]
 
 
-// Storage Nodes disk size must be at least 2097152 (2TB) if you want to install OCS and set storage count to 3
+// Storage Nodes disk size must be at least 2097152 (2TB) if you want to install OCS
 
 storage_count = 0
-storage_disk = 2097152
-//storage_ip_addresses = ["172.16.0.27", "172.16.0.28", "172.16.0.29"]
+storage_disk = 512000
+storage_ip_addresses = ["172.16.0.80", "172.16.0.81", "172.16.0.82"]
+
 
 // The IP address to assign to the loadbalancer VM.
-lb_ip_address = "172.16.0.19"
+lb_ip_address = "172.16.0.69"
 
-// including Bastion server for local DNS 161.26.0.10 is the DNS server for IBM Cloud Private Network so you can use things like NTP from IBM Cloud Private Network
-vm_dns_addresses = ["8.8.8.8","161.26.0.10"]
+// including Bastion server for local DNS
+vm_dns_addresses = ["9.9.9.9","161.26.0.10","172.16.0.10"]
 
-openshift_pull_secret = "~/pull-secret"
-additionalTrustBundle = ""
+//openshift_pull_secret = ""
+openshift_pull_secret = "<your pull secret location>"
+// additionalTrustBundle = "<your trust bundle cert if airgapped>"      
 
 
-// airgapped block see readme for details on airgapped
+openshift_version="4.6"
+// Name of the RHCOS VM template to clone to create VMs for the cluster
+rhcos_template = "rhcos OpenShift 4.6.8"
+
+// airgapped block
 airgapped = {
       enabled = false
-// ocp_ver_rel has to match version.release that you loaded in mirror
-      ocp_ver_rel = "x.x.x"
-      mirror_ip = "172.16.0.10"
-      mirror_fqdn = "mirror.airgapped.com"
-      mirror_port = "5000"
+      ocp_ver_rel = "<your version.release>"
+      mirror_ip = "<ip of mirror>" 
+      mirror_fqdn = "<fqdn of mirror>"
+      mirror_port = "<port of mirror>"
       mirror_repository = "ocp4/openshift4"
       }
 
-
-//public IP for your cluster pick one of the 5 available
-cluster_public_ip       = "161.xxx.xx.xxx"
-
+cluster_public_ip       = "x.x.x.x"
+ 
 initialization_info     = {
-    public_bastion_ip = "161.x.y.y"
-    bastion_password = "OCP4All"
+    public_bastion_ip = "y.y.y.y"
+    bastion_password = "<password for bastion>"
     internal_bastion_ip = "172.16.0.10"
     terraform_ocp_repo = "https://github.com/ibm-cloud-architecture/terraform-openshift4-vcd"
-    rhel_key = "redhat license key from VCD screen"
-    machine_cidr = "172.16.0.1/24"
+    rhel_key = "<redhat license key from vcd screen>"
+    machine_cidr = "172.16.0.0/16"
     network_name      = "ocpnet"
     static_start_address    = "172.16.0.150"
     static_end_address      = "172.16.0.220"
     bastion_template        = "RedHat-8-Template-Official"
     run_cluster_install     = true
-    start_vms               = false
     }


### PR DESCRIPTION
Airgapped install not working due to change in variable names. additionalTrustBundle was not being populated during an airgapped install so local mirror could not be read. 
Also snuck in a change to allow you set Bastion Disk size so that you can make it big enough to hold a mirror. It was originally defaulting to 20GB from Template. 