### PR TITLE
Request to fix Issue 9 

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,6 @@ airgapped = {
       mirror_fqdn = "bastion.airgapfull.cdastu.com"
       mirror_port = "5000"
       mirror_repository = "ocp4/openshift4"
-      additionalTrustBundle = "~/airgap.crt"      
       }
 ```
 ### Deleting Cluster (and reinstalling)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 
-# OpenShift UPI Deployment with Static IPs on VMWare Cloud Director
+# OpenShift Installation on IBM Cloud VMWare Solutions Shared based on VMWare Cloud Director
 ## Overview
-Deploy OpenShift 4.6 and later on VMWare Cloud Director using static IP addresses for CoreOS nodes.  The `ignition` module will inject code into the cluster that will automatically approve all node CSRs.  This runs only once at cluster creation.  You can delete the `ibm-post-deployment` namespace once your cluster is up and running.
+Deploy OpenShift on IBM Cloud VMWare Solutions based on VMWare Cloud Director.  This toolkit uses Terraform to automate the OpenShift installation process including the Edge Network configuration, Bastion host creation, OpenShift CoreOS bootstrap, loadbalancer, control and worker node creation. Once provisioned, the VMWare Cloud Director environment gives you complete control of all aspects of you OpenShift environment.
 
-**NOTE**: This requires OpenShift 4.6 or later, if you're looking for 4.5 or earlier, see the [VCD Toolkit](https://github.com/vmware-ibm-jil/vcd_toolkit_for_openshift) or the `terraform-openshift4-vmware pre-4.6` [branch](https://github.com/ibm-cloud-architecture/terraform-openshift4-vmware/tree/pre-4.6)
+The toolkit provides the flexibility to also configure "airgapped" clusters without Internet access.
+
+See also [IBM Cloud VMWare Solutions Shared overview](https://cloud.ibm.com/docs/vmwaresolutions?topic=vmwaresolutions-shared_overview)
+
+This toolkit performs an OpenShift UPI type install and will provision CoreOS nodes using static IP addresses. The `ignition` module will inject code into the cluster that will automatically approve all node CSRs.  This runs only once at cluster creation.  You can delete the `ibm-post-deployment` namespace once your cluster is up and running.
+
+**NOTE**: OpenShift 4.6 or later is supported. If you need 4.5 or earlier, see the [VCD Toolkit](https://github.com/vmware-ibm-jil/vcd_toolkit_for_openshift) or the `terraform-openshift4-vmware pre-4.6` [branch](https://github.com/ibm-cloud-architecture/terraform-openshift4-vmware/tree/pre-4.6)
 
 **NOTE**: Requires terraform 0.13 or later.  
 

--- a/bastion-vm/bastion-vm.tf
+++ b/bastion-vm/bastion-vm.tf
@@ -208,7 +208,12 @@ resource "vcd_vapp_vm" "bastion" {
   cpus          = 2
   cpu_cores     = 1
   
-
+  override_template_disk {
+    bus_type           = "paravirtual"
+    size_in_mb         = var.bastion_disk
+    bus_number         = 0
+    unit_number        = 0
+}
   # Assign IP address on the routed network 
   network {
     type               = "org"

--- a/bastion-vm/variables.tf
+++ b/bastion-vm/variables.tf
@@ -267,6 +267,10 @@ variable "cluster_public_ip" {
   type                     = string
 }
 
+variable "bastion_disk" {
+  type                     = string
+}
+
 variable "initialization_info" {
   type = object ({
     public_bastion_ip      = string

--- a/ignition/templates.tf
+++ b/ignition/templates.tf
@@ -23,8 +23,8 @@ platform:
   none: {}  
 pullSecret: '${chomp(file(var.pull_secret))}'
 sshKey: '${var.ssh_public_key}'
-%{if var.airgapped["additionalTrustBundle"] != ""}
-${indent(2, "additionalTrustBundle: |\n${file(var.airgapped["additionalTrustBundle"])}")}
+%{if var.additionalTrustBundle != ""}
+${indent(2, "additionalTrustBundle: |\n${file(var.additionalTrustBundle)}")}
 %{endif}
 %{if var.airgapped["enabled"]}imageContentSources:
 - mirrors:

--- a/ignition/templates.tf
+++ b/ignition/templates.tf
@@ -23,8 +23,8 @@ platform:
   none: {}  
 pullSecret: '${chomp(file(var.pull_secret))}'
 sshKey: '${var.ssh_public_key}'
-%{if var.additionalTrustBundle != ""}
-${indent(2, "additionalTrustBundle: |\n${file(var.additionalTrustBundle)}")}
+%{if var.airgapped["additionalTrustBundle"] != ""}
+${indent(2, "additionalTrustBundle: |\n${file(var.airgapped["additionalTrustBundle"])}")}
 %{endif}
 %{if var.airgapped["enabled"]}imageContentSources:
 - mirrors:

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ module "lb" {
   bootstrap_ip      = var.bootstrap_ip_address
   control_plane_ips = var.control_plane_ip_addresses
 
-  dns_addresses = var.create_loadbalancer_vm ? concat([var.lb_ip_address],local.mirror_repo_ip,var.vm_dns_addresses) : var.vm_dns_addresses
+  dns_addresses = var.airgapped["enabled"] ? concat([var.lb_ip_address],local.mirror_repo_ip,var.vm_dns_addresses) : var.vm_dns_addresses
 
 
   dns_ip_addresses = zipmap(

--- a/variables.tf
+++ b/variables.tf
@@ -266,6 +266,12 @@ variable "cluster_public_ip" {
   type        = string
 }
 
+variable "bastion_disk" {
+  type                     = string
+  default                  = "200000"
+}
+
+
 variable "initialization_info" {
   type = object ({
     public_bastion_ip      = string

--- a/variables.tf
+++ b/variables.tf
@@ -266,6 +266,11 @@ variable "cluster_public_ip" {
   type        = string
 }
 
+variable "bastion_disk" {
+  type        = string
+  default     = "200000"
+}
+
 variable "initialization_info" {
   type = object ({
     public_bastion_ip      = string

--- a/variables.tf
+++ b/variables.tf
@@ -266,12 +266,6 @@ variable "cluster_public_ip" {
   type        = string
 }
 
-variable "bastion_disk" {
-  type                     = string
-  default                  = "200000"
-}
-
-
 variable "initialization_info" {
   type = object ({
     public_bastion_ip      = string


### PR DESCRIPTION
Not sure what happened the first time I tried to fix this but I'll try again. This should fix the trust bundle issue. Also fixes an issue where invalid DNS server entries could be built if airgapped enabled= false. Added a size parameter for the Bastion disk  to allow for building of airgap mirror on Bastion. Closes #9 