### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,12 @@ Gather the following information that you will need when configuring the ESG:
 - Take an unused IP and set `cluster_public_ip` and for `public_bastion_ip`
 - The Red Hat Activation key can be retrieved from this screen to populate `rhel_key`
 
-
-- Your terraform.tfvars entries should look something like this:    
+- Bastion server install with online path
+  
+  **NOTE** If you are trying to install the OCP cluster using online path you should follow this part.
+    
+  - Set `run_cluster_install` to true.
+  - Your terraform.tfvars entries should look something like this:    
 ```
  cluster_public_ip  = "161.yyy.yy.yyy"
 
@@ -307,6 +311,29 @@ Gather the following information that you will need when configuring the ESG:
     static_start_address    = "172.16.0.150"
     static_end_address      = "172.16.0.220"
     run_cluster_install     = true
+    }
+```
+
+- Bastion server install with airgap path
+  
+  **NOTE** If you are trying to install the OCP cluster using the airgap path you should follow this part.
+  
+  - Set run_cluster_install to false. We need to configure the mirror registry first before we setup the cluster.
+  - Your terraform.tfvars entries should look something like this:    
+```
+ cluster_public_ip  = "161.yyy.yy.yyy"
+
+ initialization_info     = {
+    public_bastion_ip = "161.xxx.xx.xxx"
+    bastion_password = "OCP4All"
+    internal_bastion_ip = "172.16.0.10"
+    terraform_ocp_repo = "https://github.com/ibm-cloud-architecture/terraform-openshift4-vcd"
+    rhel_key = "xxxxxxxxxxxxxxxxxxxxxx"
+    machine_cidr = "172.16.0.1/24"
+    network_name      = "ocpnet"
+    static_start_address    = "172.16.0.150"
+    static_end_address      = "172.16.0.220"
+    run_cluster_install     = false
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Retrieve the [OpenShift Pull Secret](https://cloud.redhat.com/openshift/install/
 Once you have finished editing your terraform.tfvars file you can execute the following commands. Terraform will now create the Bastion, install and configure all necessary software and perform all network customizations associated with the Bastion. The terraform.tfvars file will be copied to the Bastion server. The pull secret and additionalTrustBundle will be copied to the Bastion if they were specified in terraform.tfvars and are in the specified location on the Host machine. If you plan to create the pull secret and additionalTrustBundle on the Bastion directly and didn't put them on your Host, ignore the error messages about the copy failing.
 If you set `run_cluster_install     = true`, your OCP cluster will be created automatically once the Bastion is configured. The results of the install can be found either on the Bastion in `/root/cluster_install.log` or on your Host machine in `~/cluster_install.log`.
 
-**NOTE** Please confirm if you have configured the `initialization_info` correctly using details from section [Configuring  initialization_info in terraform.tfvars file]() for your case before executing further steps.
+**NOTE** Please confirm if you have configured the `initialization_info` correctly using details from section [Configuring  initialization_info in terraform.tfvars file](#configuring--initialization_info-in-terraformtfvars-file) for your case before executing further steps.
 
 ```
 terraform -chdir=bastion-vm init --var-file="../terraform.tfvars"

--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ Gather the following information that you will need when configuring the ESG:
 ![Public IP](media/public_ip.jpg)
 
 
+#### Configuring  `initialization_info` in `terraform.tfvars` file
+
 - Take an unused IP and set `cluster_public_ip` and for `public_bastion_ip`
 - The Red Hat Activation key can be retrieved from this screen to populate `rhel_key`
 
@@ -337,12 +339,14 @@ Gather the following information that you will need when configuring the ESG:
     }
 ```
 
-### Retrieve pull secret from Red Hat sites
+#### Retrieve pull secret from Red Hat sites
 Retrieve the [OpenShift Pull Secret](https://cloud.redhat.com/openshift/install/vsphere/user-provisioned) and place in a file on the Bastion Server. Default location is `~/.pull-secret`
 
 ## Perform Bastion install
 Once you have finished editing your terraform.tfvars file you can execute the following commands. Terraform will now create the Bastion, install and configure all necessary software and perform all network customizations associated with the Bastion. The terraform.tfvars file will be copied to the Bastion server. The pull secret and additionalTrustBundle will be copied to the Bastion if they were specified in terraform.tfvars and are in the specified location on the Host machine. If you plan to create the pull secret and additionalTrustBundle on the Bastion directly and didn't put them on your Host, ignore the error messages about the copy failing.
 If you set `run_cluster_install     = true`, your OCP cluster will be created automatically once the Bastion is configured. The results of the install can be found either on the Bastion in `/root/cluster_install.log` or on your Host machine in `~/cluster_install.log`.
+
+**NOTE** Please confirm if you have configured the `initialization_info` correctly using details from section [Configuring  initialization_info in terraform.tfvars file]() for your case before executing further steps.
 
 ```
 terraform -chdir=bastion-vm init --var-file="../terraform.tfvars"


### PR DESCRIPTION
Missing tfvars section explanation for  `run_cluster_install` parameter value to be true or false , while setting up  the bastion server for airgap path .