### PR TITLE
Updated the Login to Bastion step for multiple entry points.

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ airgap.crt  pull-secret
 [root@vm-rhel8 ~]#
 
 ```
-**NOTE** If you have already created the cluster with below parameter to true, you can skip going ahead and return back to [High Level Steps for setting up the cluster](#architecture)
+**NOTE If you have already created the cluster with below parameter to true, you can skip going ahead and return back to [High Level Steps for setting up the cluster](#architecture)**
 
 ```
 initialization_info     = {
@@ -427,9 +427,12 @@ initialization_info     = {
     }
 ```
 
-**NOTE** If you have setup the bastion server as earlier step with `run_cluster_install = false` in `terrraform.tfvars` as shown below and now trying to setup OCP cluster go ahead and run the steps to install the OCP cluster from the bastion else skip further part of this step.
+##### Steps to create cluster only if you just created bastion server earlier and not the OCP cluster
 
-You can now go to the vcd directory. It is now placed in /opt/terraform. You will find your terraform.tfvars in the directory. You can inspect it to ensure that it is complete.
+**NOTE If you have setup the bastion server as earlier step with `run_cluster_install = false` in `terrraform.tfvars` as shown below and now trying to setup OCP cluster go ahead and run the steps to install the OCP cluster from the bastion else skip further part of this step.**
+
+
+* You can now go to the vcd directory. It is now placed in /opt/terraform. You will find your terraform.tfvars in the directory. You can inspect it to ensure that it is complete.
 ```
 [root@vm-rhel8 ~]# cd /opt/terraform/
 [root@vm-rhel8 terraform]# ls
@@ -439,7 +442,7 @@ csr-approve.sh  ignition      main.tf  network  README.md  temp     terraform.tf
 
 ```
 
-If your terraform.tfvars file is complete, you can run the commands to create your cluster. The FW, DNAT and /etc/hosts entries on the Bastion will now be created too. The following terraform commands needs to be executed from `/opt/terraform` dir on your bastion server.
+* If your `terraform.tfvars` file is complete from `/opt/terraform/` location on your bastion , you can run the commands to create your cluster. The FW, DNAT and /etc/hosts entries on the Bastion will now be created too. The following terraform commands needs to be executed from `/opt/terraform` dir on your bastion server.
 
 ```
 terraform init

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ airgap.crt  pull-secret
 ```
 **NOTE IF you are just setting up the bastion server and want to create mirror registry then skip further steps and return back to [High Level Steps for setting up the cluster](#architecture)**
 
-**NOTE If you have already created the cluster with below parameter to true, you can skip going ahead and return back to [High Level Steps for setting up the cluster](#architecture)**
+**NOTE If you have already created the cluster with below parameter to true and your cluster is already created, then you can skip going ahead and skip to [client-setup](#client-setup)**
 
 ```
 initialization_info     = {

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ If you set `run_cluster_install     = true`, your OCP cluster will be created au
 
 **NOTE** Please confirm if you have configured all the pre-requisites if you are following the airgap cluster install path from [Setup airgap pre-requisites](docs/airgap-cluster-setup.md#setup-airgap-pre-requisites)
 
-If your terraform.tfvars file is complete, you can run the commands to create your bastion vm and cluster. The FW, DNAT and /etc/hosts entries on the Bastion will now be created too. The following terraform commands needs to be executed from `/opt/terraform` dir on your bastion server.
+If your terraform.tfvars file is complete, you can run the commands to create your bastion vm and cluster. The FW, DNAT and /etc/hosts entries on the Bastion will now be created too. The following terraform commands needs to be executed from your host machine under dir `terraform-openshift4-vcd`
 
 
 ```
@@ -419,6 +419,22 @@ airgap.crt  pull-secret
 [root@vm-rhel8 ~]#
 
 ```
+**NOTE** If you have already created the cluster with below parameter to true, you can skip going ahead and return back to [High Level Steps for setting up the cluster as airgap install]()
+
+```
+initialization_info     = {
+    run_cluster_install     = true
+    }
+```
+
+**NOTE** If you have setup the bastion server as earlier step with then you would need to go ahead and run the steps to setup the OCP cluster from the bastion else skip further part of this step.
+
+```
+initialization_info     = {
+    run_cluster_install     = false
+    }
+```
+
 You can now go to the vcd directory. It is now placed in /opt/terraform. You will find your terraform.tfvars in the directory. You can inspect it to ensure that it is complete.
 ```
 [root@vm-rhel8 ~]# cd /opt/terraform/

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ airgap.crt  pull-secret
 [root@vm-rhel8 ~]#
 
 ```
-**NOTE** If you have already created the cluster with below parameter to true, you can skip going ahead and return back to [High Level Steps for setting up the cluster as airgap install]()
+**NOTE** If you have already created the cluster with below parameter to true, you can skip going ahead and return back to [High Level Steps for setting up the cluster](#architecture)
 
 ```
 initialization_info     = {

--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ airgap.crt  pull-secret
 [root@vm-rhel8 ~]#
 
 ```
+**NOTE IF you are just setting up the bastion server and want to create mirror registry then skip further steps and return back to [High Level Steps for setting up the cluster](#architecture)**
+
 **NOTE If you have already created the cluster with below parameter to true, you can skip going ahead and return back to [High Level Steps for setting up the cluster](#architecture)**
 
 ```
@@ -427,10 +429,9 @@ initialization_info     = {
     }
 ```
 
-##### Steps to create cluster only if you just created bastion server earlier and not the OCP cluster
-
 **NOTE If you have setup the bastion server as earlier step with `run_cluster_install = false` in `terrraform.tfvars` as shown below and now trying to setup OCP cluster go ahead and run the steps to install the OCP cluster from the bastion else skip further part of this step.**
 
+##### Steps to create cluster only if you just created bastion server earlier and not the OCP cluster
 
 * You can now go to the vcd directory. It is now placed in /opt/terraform. You will find your terraform.tfvars in the directory. You can inspect it to ensure that it is complete.
 ```

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ initialization_info     = {
     }
 ```
 
-**NOTE If you have setup the bastion server as earlier step with `run_cluster_install = false` in `terrraform.tfvars` as shown below and now trying to setup OCP cluster go ahead and run the steps to install the OCP cluster from the bastion else skip further part of this step.**
+**NOTE If you have setup the bastion server as earlier step with `run_cluster_install = false` in `terrraform.tfvars` as shown above and now trying to setup OCP cluster go ahead and run the steps to install the OCP cluster from the bastion else skip further part of this step.**
 
 ##### Steps to create cluster only if you just created bastion server earlier and not the OCP cluster
 

--- a/README.md
+++ b/README.md
@@ -427,13 +427,7 @@ initialization_info     = {
     }
 ```
 
-**NOTE** If you have setup the bastion server as earlier step with then you would need to go ahead and run the steps to setup the OCP cluster from the bastion else skip further part of this step.
-
-```
-initialization_info     = {
-    run_cluster_install     = false
-    }
-```
+**NOTE** If you have setup the bastion server as earlier step with `run_cluster_install = false` in `terrraform.tfvars` as shown below and now trying to setup OCP cluster go ahead and run the steps to install the OCP cluster from the bastion else skip further part of this step.
 
 You can now go to the vcd directory. It is now placed in /opt/terraform. You will find your terraform.tfvars in the directory. You can inspect it to ensure that it is complete.
 ```
@@ -442,6 +436,14 @@ You can now go to the vcd directory. It is now placed in /opt/terraform. You wil
 bastion-vm      haproxy.conf  lb       media    output.tf  storage  terraform.tfvars          variables.tf  vm
 csr-approve.sh  ignition      main.tf  network  README.md  temp     terraform.tfvars.example  versions.tf
 [root@vm-rhel8 terraform]#
+
+```
+
+If your terraform.tfvars file is complete, you can run the commands to create your cluster. The FW, DNAT and /etc/hosts entries on the Bastion will now be created too. The following terraform commands needs to be executed from `/opt/terraform` dir on your bastion server.
+
+```
+terraform init
+terraform apply --auto-approve
 
 ```
 

--- a/docs/airgap-cluster-setup.md
+++ b/docs/airgap-cluster-setup.md
@@ -44,7 +44,7 @@ trust list | grep -i "<hostname>"
 
 You need a mirror registry to mirror the OCP release images so it can be used to create the OCP cluster further. A simple registry setup instructions can be found [here](https://www.redhat.com/sysadmin/simple-container-registry).
 
-In order to prevent an x509 untrusted CA error during the terraform apply step, you must currently copy your mirror certificate to this directory and trust it. I should be able to fix this in the future.  
+* In order to prevent an x509 untrusted CA error during the terraform apply step, you must currently copy your mirror certificate to this directory and trust it. I should be able to fix this in the future.  
 ```
 cp <your mirror cert> /etc/pki/ca-trust/source/anchors/
 update-ca-trust

--- a/docs/airgap-cluster-setup.md
+++ b/docs/airgap-cluster-setup.md
@@ -11,7 +11,7 @@ Please follow the steps from main document [high level steps to setup the airgap
 
 #### Setting up mirror registry
 
-**NOTE**: If you have a mirror registry already setup  with the OCP images mirrored , in some other VCD by your team, then you can skip setting up the mirror registry and directly create the OCP cluster by following the instructions [Create the airgap cluster from bastion server](#create-the-airgap-cluster-from-bastion-server)
+**NOTE**: If you have a mirror registry already setup  with the OCP images mirrored , in some other VCD by your team, then you can skip setting up the mirror registry and directly create the OCP cluster by following the instructions [High Level Steps for setup cluster](../README.md#architecture)
 
 You need a mirror registry to mirror the OCP release images so it can be used to create the OCP cluster further. A simple registry setup instructions can be found [here](https://www.redhat.com/sysadmin/simple-container-registry).
 

--- a/docs/airgap-cluster-setup.md
+++ b/docs/airgap-cluster-setup.md
@@ -13,6 +13,28 @@ Please follow the steps from main document [high level steps to setup the airgap
 
 **NOTE**: If you have a mirror registry already setup  with the OCP images mirrored , in some other VCD by your team, then you can skip setting up the mirror registry and directly create the OCP cluster by following the instructions [High Level Steps for setup cluster](../README.md#architecture)
 
+
+##### Setting up of registry via automated script
+
+You can run this script [setup_simple_private_registry.sh](scripts/setup_simple_private_registry.sh) to setup simple private registry on your bastion server
+
+* You need to edit the below parameters in the script [setup_simple_private_registry.sh](scripts/setup_simple_private_registry.sh)
+
+```sh
+
+registry_username_to_be_created="<username you want>"
+registry_password_to_be_set="<password you want>"
+
+```
+
+* Now you can execute the script to install the Strimzi operator
+
+```
+ ./scripts/setup_simple_private_registry.sh
+```
+
+##### Setting up of registry manually via redhat documented steps
+
 You need a mirror registry to mirror the OCP release images so it can be used to create the OCP cluster further. A simple registry setup instructions can be found [here](https://www.redhat.com/sysadmin/simple-container-registry).
 
 In order to prevent an x509 untrusted CA error during the terraform apply step, you must currently copy your mirror certificate to this directory and trust it. I should be able to fix this in the future.  

--- a/docs/airgap-cluster-setup.md
+++ b/docs/airgap-cluster-setup.md
@@ -33,7 +33,7 @@ registry_password_to_be_set="<password you want>"
  ./scripts/setup_simple_private_registry.sh
 ```
 
-In order to prevent an x509 untrusted CA error during the terraform apply step, you must currently copy your mirror certificate to this directory and trust it. I should be able to fix this in the future.  
+* In order to prevent an x509 untrusted CA error during the terraform apply step, you must currently copy your mirror certificate to this directory and trust it. I should be able to fix this in the future.  
 ```
 cp <your mirror cert> /etc/pki/ca-trust/source/anchors/
 update-ca-trust

--- a/docs/airgap-cluster-setup.md
+++ b/docs/airgap-cluster-setup.md
@@ -33,6 +33,13 @@ registry_password_to_be_set="<password you want>"
  ./scripts/setup_simple_private_registry.sh
 ```
 
+In order to prevent an x509 untrusted CA error during the terraform apply step, you must currently copy your mirror certificate to this directory and trust it. I should be able to fix this in the future.  
+```
+cp <your mirror cert> /etc/pki/ca-trust/source/anchors/
+update-ca-trust
+trust list | grep -i "<hostname>"
+```
+
 ##### Setting up of registry manually via redhat documented steps
 
 You need a mirror registry to mirror the OCP release images so it can be used to create the OCP cluster further. A simple registry setup instructions can be found [here](https://www.redhat.com/sysadmin/simple-container-registry).
@@ -88,6 +95,13 @@ This is special step and you have to perform it only if you have your mirror reg
 
 ```
 additionalTrustBundle = "/opt/registry/certs/domain.crt"
+```
+
+In order to prevent an x509 untrusted CA error during the terraform apply step, you must currently copy your mirror certificate to this directory and trust it. I should be able to fix this in the future.  
+```
+cp <your mirror cert> /etc/pki/ca-trust/source/anchors/
+update-ca-trust
+trust list | grep -i "<hostname>"
 ```
 
 ##### Update the terraform.tfvars airgap parameters

--- a/docs/airgap-cluster-setup.md
+++ b/docs/airgap-cluster-setup.md
@@ -97,7 +97,7 @@ This is special step and you have to perform it only if you have your mirror reg
 additionalTrustBundle = "/opt/registry/certs/domain.crt"
 ```
 
-In order to prevent an x509 untrusted CA error during the terraform apply step, you must currently copy your mirror certificate to this directory and trust it. I should be able to fix this in the future.  
+* In order to prevent an x509 untrusted CA error during the terraform apply step, you must currently copy your mirror certificate to this directory and trust it. I should be able to fix this in the future.  
 ```
 cp <your mirror cert> /etc/pki/ca-trust/source/anchors/
 update-ca-trust

--- a/docs/airgap-cluster-setup.md
+++ b/docs/airgap-cluster-setup.md
@@ -17,7 +17,7 @@ You need a mirror registry to mirror the OCP release images so it can be used to
 
 In order to prevent an x509 untrusted CA error during the terraform apply step, you must currently copy your mirror certificate to this directory and trust it. I should be able to fix this in the future.  
 ```
-cp <your mirror cert>/etc/pki/ca-trust/source/anchors/
+cp <your mirror cert> /etc/pki/ca-trust/source/anchors/
 update-ca-trust
 trust list | grep -i "<hostname>"
 ```

--- a/docs/scripts/install_rook-cephfs_airgap.sh
+++ b/docs/scripts/install_rook-cephfs_airgap.sh
@@ -1,0 +1,84 @@
+rook_ceph_images_url=("docker.io/rook/ceph:v1.5.8"
+            "docker.io/ceph/ceph:v15.2.9"
+            "quay.io/cephcsi/cephcsi:v3.2.0"
+            "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1"
+            "k8s.gcr.io/sig-storage/csi-resizer:v1.0.0"
+            "k8s.gcr.io/sig-storage/csi-provisioner:v2.0.0"
+            "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.0"
+            "k8s.gcr.io/sig-storage/csi-attacher:v3.0.0")
+
+# This is your mirror registry where you want to mirror the strimzi images
+mirror_registry="<mirror-registry>:<port>"
+
+#Provide the creds for your mirror registry
+mirror_registry_username="username"
+mirror_registry_password="password"
+
+echo "Trying to login to the mirror registry $mirror_registry"
+podman login -u $mirror_registry_username -p $mirror_registry_password $mirror_registry --tls-verify=false
+if [ $? -gt 0 ]; then
+   echo "[ERROR] Some error occured while login to the mirror registry $mirror_registry"
+   exit 1
+fi
+
+for image in ${rook_ceph_images_url[@]}; do
+    echo "[INFO] Mirroring the image: $image"
+    podman pull $image --tls-verify=false
+
+    updated_image=""
+    if [[ $image == *"docker.io"* ]]; then
+       echo "Updating the $image with docker.io"
+       updated_image="$(echo $image | sed 's|docker.io|'"$mirror_registry"'|g')"
+    elif [[ $image == *"quay.io"* ]]; then
+       echo "Updating the $image with quay.io"
+       updated_image="$(echo $image | sed 's|quay.io|'"$mirror_registry"'|g')"
+    elif [[ $image == *"k8s.gcr.io"* ]]; then  
+       echo "Updating the $image with k8s.gcr.io"
+       updated_image="$(echo $image | sed 's|k8s.gcr.io|'"$mirror_registry"'|g')"   
+    fi 
+ 
+    echo "[INFO] Tagging image $image to $updated_image"
+    podman tag $image $updated_image
+    echo "[INFO] Pushing image $updated_image to your mirror repository "
+    podman push $updated_image --tls-verify=false
+done
+
+
+if [ -d "rook" ]; then
+   rm -rf rook
+fi
+echo "[INFO] git cloning the repository rook --branch v1.5.8"
+git clone https://github.com/rook/rook --branch v1.5.8
+
+
+#updating all the image registry to mirror registry
+sed -i 's|rook/ceph:|'"$mirror_registry"'/rook/ceph:|g' rook/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+sed -i 's|quay.io|'"$mirror_registry"'|g' rook/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+sed -i 's|k8s.gcr.io|'"$mirror_registry"'|g' rook/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+sed -i 's|ceph/ceph:|'"$mirror_registry"'/ceph/ceph:|g' rook/cluster/examples/kubernetes/ceph/cluster.yaml
+
+
+#uncommenting the env variables for image
+sed -i 's|# ROOK_CSI_CEPH_IMAGE|ROOK_CSI_CEPH_IMAGE|g' rook/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+sed -i 's|# ROOK_CSI_REGISTRAR_IMAGE|ROOK_CSI_REGISTRAR_IMAGE|g' rook/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+sed -i 's|# ROOK_CSI_RESIZER_IMAGE|ROOK_CSI_RESIZER_IMAGE|g' rook/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+sed -i 's|# ROOK_CSI_PROVISIONER_IMAGE|ROOK_CSI_PROVISIONER_IMAGE|g' rook/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+sed -i 's|# ROOK_CSI_SNAPSHOTTER_IMAGE|ROOK_CSI_SNAPSHOTTER_IMAGE|g' rook/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+sed -i 's|# ROOK_CSI_ATTACHER_IMAGE|ROOK_CSI_ATTACHER_IMAGE|g' rook/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+
+echo "[INFO] Applying the yamls to setup rook-cephfs storage"
+oc apply -f ./rook/cluster/examples/kubernetes/ceph/crds.yaml
+
+oc apply -f ./rook/cluster/examples/kubernetes/ceph/common.yaml
+oc apply -f ./rook/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+oc apply -f ./rook/cluster/examples/kubernetes/ceph/cluster.yaml
+oc apply -f ./rook/cluster/examples/kubernetes/ceph/filesystem.yaml
+oc apply -f ./rook/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
+oc apply -f ./rook/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-test.yaml
+
+if [ $? -gt 0 ]; then
+   echo "[ERROR] Some issue occured while setting up yamls for rook-cephfs storage"
+   exit 1
+else
+   echo "[INFO] rook-cephfs storage setup completed, please verify all the pods are running with command 'oc get pods -n rook-ceph' "
+fi 

--- a/docs/scripts/setup_simple_private_registry.sh
+++ b/docs/scripts/setup_simple_private_registry.sh
@@ -1,0 +1,103 @@
+#Followed this document to script this automated script for setting up simple private registry
+#https://www.redhat.com/sysadmin/simple-container-registry
+
+registry_username_to_be_created="<username you want>"
+registry_password_to_be_set="<password you want>"
+
+registry_dir="/opt/registry"
+
+cert_key_file="$HOSTNAME.key"
+cert_crt_file="$HOSTNAME.crt"
+
+echo "[INFO] Checking Pre-requisites:"
+if podman -v > /dev/null ;then
+   echo "[INFO] Pre-requisite 'Podman' exists"
+else
+   echo "[ERROR] Pre-requisite 'Podman' does not exists, please install and try again"
+   exit 1
+fi
+
+#installing httpd-tools
+echo "[INFO] Installing httpd-tools"
+yum install -y podman httpd-tools
+
+echo "[INFO] Creating directories $registry_dir/{auth,certs,data} if it does not exists"
+if [ ! -d "$registry_dir" ]; then
+   mkdir -p $registry_dir
+fi
+mkdir -p $registry_dir/{auth,certs,data}
+
+echo "[INFO] Generate credentials for accessing the registry"
+echo "[INFO] Username as provided : $registry_username_to_be_created"
+echo "[INFO] Password as provided : $registry_password_to_be_set"
+htpasswd -bBc /opt/registry/auth/htpasswd $registry_username_to_be_created $registry_password_to_be_set
+
+echo "[INFO] Navigating to directory $registry_dir"
+cd $registry_dir
+
+echo "[INFO] Common Name to be used for registry tls key and cert :--------->>>>>> Hostname='$HOSTNAME' <<<<<<<---------"
+
+echo "[INFO] The registry is secured with TLS by using a key and certificate signed by a simple self-signed certificate. "
+echo "[INFO] Creating self-signed certificate in directory $registry_dir/certs"
+openssl req -newkey rsa:4096 -nodes -sha256 -keyout $registry_dir/certs/$cert_key_file -x509 -days 365 -out $registry_dir/certs/$cert_crt_file
+
+echo "[INFO] The certificate will also have to be trusted by your hosts and clients"
+echo "[INFO] Copying '$registry_dir/certs/$cert_crt_file' to directory '/etc/pki/ca-trust/source/anchors/'"
+cp $registry_dir/certs/$cert_crt_file /etc/pki/ca-trust/source/anchors/
+
+echo "[INFO] Updating the ca trust"
+update-ca-trust
+
+echo "[INFO] Printing the trust list with hostname=$HOSTNAME"
+echo "Trust List : $(trust list | grep -i $HOSTNAME)"
+
+echo "[INFO] Starting  the registry"
+podman run --name myregistry \
+-p 5000:5000 \
+-v $registry_dir/data:/var/lib/registry:z \
+-v $registry_dir/auth:/auth:z \
+-e "REGISTRY_AUTH=htpasswd" \
+-e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
+-e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
+-v $registry_dir/certs:/certs:z \
+-e "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/$cert_crt_file" \
+-e "REGISTRY_HTTP_TLS_KEY=/certs/$cert_key_file" \
+-e REGISTRY_COMPATIBILITY_SCHEMA1_ENABLED=true \
+-d \
+docker.io/library/registry:latest
+
+echo "[INFO] Registry container started :"
+echo "[INFO] ================================================================================================================"
+podman ps
+echo "[INFO] ================================================================================================================"
+   
+firewall-cmd --add-port=5000/tcp --zone=internal --permanent
+firewall-cmd --add-port=5000/tcp --zone=public --permanent
+firewall-cmd --reload
+
+registry_container_id=$(podman ps --format "{{.ID}}")
+echo "registry_container_id=$registry_container_id"
+
+echo "[INFO] Restarting the registry container"
+podman restart $registry_container_id
+
+if [ $? -gt 0 ]; then
+   echo "[ERROR] Some issue in setting up your registry"
+   exit 1
+else
+   echo "[INFO] Your registry was setup successfully"
+   echo "[INFO] ================================================================================================================"
+   echo "[INFO] Registry Information to access it from client machine"
+   echo "[INFO] ================================================================================================================"
+   echo "[INFO] Registry crt file is present in directory path :  '$registry_dir/certs/$cert_crt_file' "
+   echo "[INFO] This crt file can be copied to the client machine at path '$registry_dir/certs/$cert_crt_file' from where you want to login to this registry"
+   echo "[INFO] You need to execute these commands on client where you want to login to this registry"
+   echo "[INFO] 'cp $registry_dir/certs/$cert_crt_file /etc/pki/ca-trust/source/anchors/'"
+   echo "[INFO] 'update-ca-trust'"
+   echo "[INFO] Verify the ca trues list is updated successfully by command :"
+   echo "[INFO] trust list | grep -i \"$HOSTNAME\""
+   echo "[INFO] ================================================================================================================"
+   echo "[INFO] You can login finally to the registry with command 'GODEBUG=x509ignoreCN=0 podman login $HOSTNAME:5000 -u $registry_username_to_be_created -p $registry_password_to_be_set --cert-dir \"/etc/pki/ca-trust/source/anchors/\"' "
+   echo "[INFO] ================================================================================================================"
+ 
+fi


### PR DESCRIPTION
Added NOTE for different entry points to Login to Bastion step.
1. Re-routed in case someone needs to login to bastion and setup registry
2. Re-routed in cases someone already created bastion and created cluster as one step, the linked to `client-setup`
3. Mentioned that if you have bastion server only , and needs to create cluster from bastion server then follow steps of `terraform init ` and `terraform apply` from `/opt/terraform/` from your bastion server.
4. Added `setup_simple_private_registry.sh ` as automated way for setting up the simple private registry on bastion server