### PR TITLE
Changing the placement of -f option

### DIFF
--- a/bastion-vm/scripts/fix_ssh.sh.tmpl
+++ b/bastion-vm/scripts/fix_ssh.sh.tmpl
@@ -4,5 +4,5 @@ echo "n" | ssh-keygen -t ed25519 -N ''  -f ~/.ssh/id_bastion
 ssh-keygen -R ${public_bastion_ip}
 #ssh-agent bash
 #ssh-add ~/.ssh/id_bastion
-sshpass -p ${bastion_password} ssh-copy-id -o StrictHostKeyChecking=no -i ~/.ssh/id_bastion root@${public_bastion_ip} -f 
+sshpass -p ${bastion_password} ssh-copy-id -f -o StrictHostKeyChecking=no -i ~/.ssh/id_bastion root@${public_bastion_ip} 
 


### PR DESCRIPTION
## Overview
When running the `terraform apply` to create the bastion and cluster, the `setup_ssh` action will fail due to "too many arguments" in the ssh-copy-id command. After moving the `-f` option this error was resolved and the `setup_ssh` progressed.
```console
Host 150.239.172.192 not found in /Users/liamsalazar/.ssh/known_hosts
│ /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/Users/liamsalazar/.ssh/id_bastion.pub"
│ /usr/bin/ssh-copy-id: ERROR: Too many arguments.  Expecting a target hostname, got: 
│ 
│ Usage: /usr/bin/ssh-copy-id [-h|-?|-f|-n|-s] [-i [identity_file]] [-p port] [-F alternative ssh_config file]
│ [[-o <ssh -o options>] ...] [user@]hostname
│       -f: force mode -- copy keys without trying to check if they are already installed
│       -n: dry run    -- no keys are actually copied
│       -s: use sftp   -- use sftp instead of executing remote-commands. Can be useful if the remote only allows
│ sftp
│       -h|-?: print this help
│ 
╵
```